### PR TITLE
OpenSource delegate helm chart: Add delegate chart for NG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*iml
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 ## Contributor License Agreement
 
 In order to clarify the intellectual property license granted with Contributions from any person or entity, Harness Inc. ("Harness") must have a Contributor License Agreement ("CLA") on file that has been read and followed by each contributor, indicating an agreement to the license terms [here](https://github.com/harness-apps/delegate-helm-chart/blob/main/Contributor_license_agreement.md). This license is for your protection as a Contributor as well as the protection of Harness; it does not change your rights to use your own Contributions for any other purpose.
+
+## Instructions to publish new chart
+1. Update version field in `Chart.yaml`
+2. Package chart: `helm package <chart_dir>`
+3. Update index file: `helm repo index . --merge index.yaml`
+4. Git Commit and push changes for PR (excluding packaged chart)
+    

--- a/harness-delegate-ng/.helmignore
+++ b/harness-delegate-ng/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/harness-delegate-ng/Chart.yaml
+++ b/harness-delegate-ng/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: harness-delegate-ng
+description: A Helm chart for deploying harness-delegate
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.3
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/harness-delegate-ng/README.md
+++ b/harness-delegate-ng/README.md
@@ -1,0 +1,56 @@
+# Harness Delegate
+
+[Harness Delegate](https://docs.harness.io/article/de9t8iiynt-harness-architecture) is a service you run in your local network or VPC to connect your artifact servers, infrastructure, collaboration, and verification providers with the Harness Manager.
+
+## Introduction
+
+This chart creates a [Harness Delegate](https://docs.harness.io/article/h9tkwmkrm7-delegate-installation) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+
+## Installing the Chart
+To add Harness helm repo with name `harness`:
+
+This chart is only compatible with helm version >= 3.2
+
+```console
+$ helm repo add harness https://app.harness.io/storage/harness-download/harness-helm-charts/
+```
+
+The chart requires some account specific information. You can
+download the account specific `delegate-helm-values.yaml` by going to
+Harness > Setup > Installations page
+
+To install the chart with the namespace `my-namespace` and `delegate-helm-values.yaml`
+
+```console
+$ helm upgrade -i <delegate-name> --namespace my-namespace --create-namespace ./harness-delegate-ng -f harness-delegate-values.yaml
+```
+The command deploys Harness delegate on the Kubernetes cluster.
+
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm uninstall my-release
+```
+
+## Useful commands
+
+Get pod names:
+
+```console
+kubectl get pods -n <namespace>
+```
+
+See startup logs:
+
+```console
+kubectl logs <pod-name> -n <namespace> -f
+```
+Run a shell in a pod:
+
+```console
+kubectl exec <pod-name> -n <namespace> -it -- bash
+```

--- a/harness-delegate-ng/templates/_helpers.tpl
+++ b/harness-delegate-ng/templates/_helpers.tpl
@@ -1,0 +1,79 @@
+{{/*
+The release name, default is set to chart name if delegate name is not specified.
+*/}}
+{{- define "harness-delegate-ng.name" -}}
+{{- default .Chart.Name .Values.delegateName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name, this is same as delegate name unless an override is specified.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If delegateName is not provided chart name would be used by default.
+*/}}
+{{- define "harness-delegate-ng.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.delegateName }}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "harness-delegate-ng.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "harness-delegate-ng.labels" -}}
+helm.sh/chart: {{ include "harness-delegate-ng.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "harness-delegate-ng.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "harness-delegate-ng.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "harness-delegate-ng.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+harness.io/name: {{ template "harness-delegate-ng.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "harness-delegate-ng.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "harness-delegate-ng.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Fetch access level using kubernetes permission value
+*/}}
+{{- define "harness-delegate-ng.accessLevel" -}}
+  {{- if eq .Values.k8sPermissionsType "CLUSTER_ADMIN" }}
+    {{- print "cluster-admin" }}
+  {{- else if eq .Values.k8sPermissionsType "CLUSTER_VIEWER" -}}
+    {{- print "view" }}
+  {{- else if eq .Values.k8sPermissionsType "NAMESPACE_ADMIN" }}
+    {{- print "namespace-admin" }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Memory assigned to container in Mi
+*/}}
+{{- define "harness-delegate-ng.assignedMemory" -}}
+  {{- $allocatedRam := .Values.memory | toString }}
+  {{- printf "%s%s" $allocatedRam "Mi" }}
+{{- end }}
+
+

--- a/harness-delegate-ng/templates/cluster-rolebinding.yaml
+++ b/harness-delegate-ng/templates/cluster-rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- $clusterRoleBindingName := printf "%s-%s" .Release.Namespace .Values.k8sPermissionsType | lower | replace "_" "-" -}}
+{{- if or (eq .Values.k8sPermissionsType "CLUSTER_ADMIN") (eq .Values.k8sPermissionsType "CLUSTER_VIEWER")}}
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" .Release.Namespace $clusterRoleBindingName) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Values.k8sPermissionsType | lower | replace "_" "-" }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "harness-delegate-ng.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "harness-delegate-ng.accessLevel" .}}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/harness-delegate-ng/templates/configMap.yaml
+++ b/harness-delegate-ng/templates/configMap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+data:
+  ACCOUNT_ID: {{ required "A valid .Values.accountId entry required!" .Values.accountId }}
+  MANAGER_HOST_AND_PORT : {{ .Values.managerEndpoint }}
+  DEPLOY_MODE: "KUBERNETES"
+  DELEGATE_NAME: {{ .Values.delegateName | quote }}
+  POLL_FOR_TASKS: {{ .Values.pollForTasks | quote }}
+  NEXT_GEN: "true"
+  DELEGATE_TAGS: {{ .Values.tags | quote }}
+  DELEGATE_DESCRIPTION: {{ .Values.description | quote }}
+  JAVA_OPTS: {{ .Values.javaOpts }}
+  DELEGATE_TYPE: {{ .Values.delegateType }}
+  DELEGATE_NAMESPACE: {{ .Release.Namespace }}
+  INIT_SCRIPT: {{ .Values.initScript | quote }}
+  CLIENT_TOOLS_DOWNLOAD_DISABLED: "true"
+  LOG_STREAMING_SERVICE_URL: {{ .Values.managerEndpoint }}/log-service/
+
+

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+  name: {{ include "harness-delegate-ng.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "harness-delegate-ng.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3460"
+        prometheus.io/path: "/api/metrics"
+        checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum | trunc 63 }}
+        checksum/configmap: {{ include (print .Template.BasePath "/configMap.yaml") . | sha256sum | trunc 63 }}
+      labels:
+        {{- include "harness-delegate-ng.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "harness-delegate-ng.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 600
+      restartPolicy: Always
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ .Values.delegateDockerImage }}
+          {{- if .Values.securityContext.runAsRoot }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 0
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          resources:
+            limits:
+              memory: {{ include "harness-delegate-ng.assignedMemory" .}}
+            requests:
+              cpu: {{ .Values.cpu }}
+              memory: {{ include "harness-delegate-ng.assignedMemory" .}}
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: 3460
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds:  {{ .Values.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3460
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          envFrom:
+            - configMapRef:
+                name: {{ template "harness-delegate-ng.fullname" . }}
+            - secretRef:
+                name: {{ template "harness-delegate-ng.fullname" . }}
+            - configMapRef:
+                name: {{ template "harness-delegate-ng.fullname" . }}-proxy
+                optional: true
+            - secretRef:
+                name: {{ template "harness-delegate-ng.fullname" . }}-proxy
+                optional: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/harness-delegate-ng/templates/hpa.yaml
+++ b/harness-delegate-ng/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "harness-delegate-ng.fullname" . }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "harness-delegate-ng.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/harness-delegate-ng/templates/proxy/proxyConfigMap.yaml
+++ b/harness-delegate-ng/templates/proxy/proxyConfigMap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.proxyHost }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}-proxy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+data:
+  PROXY_HOST: {{ .Values.proxyHost | quote }}
+  PROXY_PORT: {{ .Values.proxyPort | quote }}
+  PROXY_SCHEME: {{ .Values.proxyScheme | quote }}
+  NO_PROXY: {{ .Values.noProxy | quote }}
+{{- end }}
+
+

--- a/harness-delegate-ng/templates/proxy/proxySecret.yaml
+++ b/harness-delegate-ng/templates/proxy/proxySecret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.proxyHost }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}-proxy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+type: Opaque
+data:
+  # Enter base64 encoded username and password if using proxy
+  PROXY_USER: {{ .Values.proxyUser }}
+  PROXY_PASSWORD: {{ .Values.proxyPassword }}
+{{- end }}

--- a/harness-delegate-ng/templates/role.yaml
+++ b/harness-delegate-ng/templates/role.yaml
@@ -1,0 +1,15 @@
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "Role" .Release.Namespace "harness-namespace-admin") }}
+{{- if eq .Values.k8sPermissionsType "NAMESPACE_ADMIN" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: harness-namespace-admin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+{{- end }}
+{{- end }}

--- a/harness-delegate-ng/templates/roleBinding.yaml
+++ b/harness-delegate-ng/templates/roleBinding.yaml
@@ -1,0 +1,20 @@
+{{- $roleBindingName := print .Release.Namespace "-harness-namespace-admin" -}}
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "RoleBinding" .Release.Namespace $roleBindingName) }}
+{{- if eq .Values.k8sPermissionsType "NAMESPACE_ADMIN" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-harness-namespace-admin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "harness-delegate-ng.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: harness-namespace-admin
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/harness-delegate-ng/templates/secret.yaml
+++ b/harness-delegate-ng/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+type: Opaque
+data:
+  # Base 64 encoded account secret
+  DELEGATE_TOKEN: {{ .Values.delegateToken | b64enc | quote }}

--- a/harness-delegate-ng/templates/service.yaml
+++ b/harness-delegate-ng/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: delegate-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+  selector:
+    {{- include "harness-delegate-ng.selectorLabels" . | nindent 4 }}

--- a/harness-delegate-ng/templates/serviceaccount.yaml
+++ b/harness-delegate-ng/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "harness-delegate-ng.serviceAccountName" . }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.upgrader.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}-upgrader-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    mode: Delegate
+    dryRun: false
+    workloadName: {{ .Values.delegateName }}
+    namespace: {{ .Release.Namespace }}
+    containerName: delegate
+    delegateConfig:
+      accountId: {{ .Values.accountId }}
+      managerHost: {{ .Values.managerEndpoint }}
+{{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.upgrader.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+  name: {{ template "harness-delegate-ng.fullname" . }}-upgrader-job
+  namespace: {{ .Release.Namespace }}
+spec:
+  schedule: "0 */1 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 20
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Values.upgrader.cronJobServiceAccountName }}
+          restartPolicy: Never
+          containers:
+            - image: {{ .Values.upgrader.upgraderDockerImage }}
+              name: upgrader
+              imagePullPolicy: Always
+              envFrom:
+                - secretRef:
+                    name: {{ .Values.delegateName }}-upgrader-token
+              volumeMounts:
+                - name: config-volume
+                  mountPath: /etc/config
+          volumes:
+            - name: config-volume
+              configMap:
+                name: {{ .Values.delegateName }}-upgrader-config
+{{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderRole.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderRole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.upgrader.enabled -}}
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "Role" .Release.Namespace "upgrader-role" ) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: upgrader-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["batch", "apps", "extensions"]
+    resources: ["cronjobs"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+{{- end }}
+{{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderRoleBinding.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderRoleBinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.upgrader.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}-upgrader-cronjob
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.upgrader.cronJobServiceAccountName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: upgrader-role
+  apiGroup: ""
+{{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderSecret.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderSecret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.upgrader.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}-upgrader-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+type: Opaque
+data:
+  UPGRADER_TOKEN: {{ .Values.delegateToken | b64enc | quote }}
+{{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderServiceAccount.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderServiceAccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.upgrader.enabled -}}
+{{- if not (lookup "v1" "ServiceAccount" .Release.Namespace  .Values.upgrader.cronJobServiceAccountName ) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.upgrader.cronJobServiceAccountName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -1,0 +1,92 @@
+# Default values for delegate-ng.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  pullPolicy: Always
+
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+service:
+  type: ClusterIP
+  port: 8080
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Account Id to which the delegate will be connecting
+accountId: ""
+# Account Secret
+accountSecret: ""
+# Delegate Token
+delegateToken: ""
+
+delegateName: harness-delegate-ng
+
+delegateDockerImage: harness/delegate-immutable:75275
+
+# Endpoint that will point to harness platform. For accessing SAAS platform use the default value.
+managerEndpoint: https://app.harness.io
+
+# If socket connection is not supported, set this flag to true to poll tasks using rest API calls
+pollForTasks: "false"
+
+# Change this to alter startup probe and liveness probe settings
+startupProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 40
+
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 2
+
+# Add delegate description and tags
+description: ""
+tags: ""
+
+# Permissions for installed delegate, could be CLUSTER_ADMIN, CLUSTER_VIEWER or NAMESPACE_ADMIN
+k8sPermissionsType: "CLUSTER_ADMIN"
+
+# Number of pod replica running delegate image
+replicas: 1
+
+# Resource limits of container running delegate image in kubernetes
+cpu: 0.5
+memory: 2048
+
+# Script to run before delegate installation
+initScript: ""
+
+delegateType: "HELM_DELEGATE"
+
+javaOpts: "-Xms64M"
+
+upgrader:
+  enabled: true
+  upgraderDockerImage: "harness/upgrader:latest"
+  cronJobServiceAccountName: "upgrader-cronjob-sa"
+
+securityContext:
+  runAsRoot: true
+

--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+entries:
+  harness-delegate-ng:
+  - apiVersion: v2
+    appVersion: 1.16.0
+    created: "2022-11-07T15:15:29.12442+05:30"
+    description: A Helm chart for deploying harness-delegate
+    digest: 2fcc420a2a9cc396a000c977c536f8e5d510b6208312fc88b7c2c0cd2fd159e9
+    name: harness-delegate-ng
+    type: application
+    urls:
+    - harness-delegate-ng-1.0.3.tgz
+    version: 1.0.3
+  - apiVersion: v2
+    appVersion: 1.16.0
+    created: "2022-10-05T00:57:20.428698+05:30"
+    description: A Helm chart for deploying harness-delegate
+    digest: d067fde81f3a433db6b1a857a0f1699debba7427f09e47262910bdaeecb1c805
+    name: harness-delegate-ng
+    type: application
+    urls:
+    - harness-delegate-ng-1.0.2.tgz
+    version: 1.0.2
+  - apiVersion: v2
+    appVersion: 1.16.0
+    created: "2022-10-05T00:57:20.428128+05:30"
+    description: A Helm chart for deploying harness-delegate
+    digest: 6542ad07e85b43892143eadea87282d20c3d11c21f3502d619c967a68f6c0faf
+    name: harness-delegate-ng
+    type: application
+    urls:
+    - harness-delegate-ng-1.0.1.tgz
+    version: 1.0.1
+  - apiVersion: v2
+    appVersion: 1.16.0
+    created: "2022-08-11T15:44:06.306206+05:30"
+    description: A Helm chart for Kubernetes
+    digest: 0b2522c317a17ff0a2976a80390c484af26545a117c0f4efb59e47783528f3aa
+    name: harness-delegate-ng
+    type: application
+    urls:
+    - harness-delegate-ng-1.0.0.tgz
+    version: 1.0.0
+  - apiVersion: v2
+    appVersion: 1.16.0
+    created: "2022-08-11T15:44:06.30569+05:30"
+    description: A Helm chart for Kubernetes
+    digest: 160530e3301a47dcdfb1abb977757cfe5c42cdf3ca26a20c7e040566cda9454c
+    name: harness-delegate-ng
+    type: application
+    urls:
+    - harness-delegate-ng-0.1.0.tgz
+    version: 0.1.0
+generated: "2022-11-07T15:15:29.123288+05:30"


### PR DESCRIPTION
1 - Copied internal harness-delegate-ng helm chart here. 
2- Added contributor license as part of previous commit.
3- modified index.yaml and only copied fields only related to harness-delegate-ng 
4- branch protection is added to main, push is disabled without an approval from member of harness-app. 

related secops ticket for ref: https://harness.atlassian.net/browse/SECOPS-4403 

Testing:
delegate works fine when installed using local repo, will test in QA env after merging of pr.