### PR TITLE
Increase liveness probe for helm delegate

### DIFF
--- a/harness-delegate-ng/Chart.yaml
+++ b/harness-delegate-ng/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -42,7 +42,7 @@ delegateToken: ""
 
 delegateName: harness-delegate-ng
 
-delegateDockerImage: harness/delegate-immutable:75275
+delegateDockerImage: ""
 
 # Endpoint that will point to harness platform. For accessing SAAS platform use the default value.
 managerEndpoint: https://app.harness.io

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -57,9 +57,9 @@ startupProbe:
   failureThreshold: 40
 
 livenessProbe:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 2
+  initialDelaySeconds: 30
+  periodSeconds: 20
+  failureThreshold: 3
 
 # Add delegate description and tags
 description: ""

--- a/index.yaml
+++ b/index.yaml
@@ -3,9 +3,9 @@ entries:
   harness-delegate-ng:
   - apiVersion: v2
     appVersion: 1.16.0
-    created: "2022-11-07T15:15:29.12442+05:30"
+    created: "2022-11-22T14:29:12.077663+05:30"
     description: A Helm chart for deploying harness-delegate
-    digest: 2fcc420a2a9cc396a000c977c536f8e5d510b6208312fc88b7c2c0cd2fd159e9
+    digest: b8334e36bf896dcd89345b3ac6c8622eca5b85741fb86f2afe560c433c50ad26
     name: harness-delegate-ng
     type: application
     urls:
@@ -51,4 +51,4 @@ entries:
     urls:
     - harness-delegate-ng-0.1.0.tgz
     version: 0.1.0
-generated: "2022-11-07T15:15:29.123288+05:30"
+generated: "2022-11-22T14:29:12.07653+05:30"

--- a/index.yaml
+++ b/index.yaml
@@ -3,6 +3,16 @@ entries:
   harness-delegate-ng:
   - apiVersion: v2
     appVersion: 1.16.0
+    created: "2022-11-23T12:02:19.430104+05:30"
+    description: A Helm chart for deploying harness-delegate
+    digest: e0a29df9e076e791718c741e1da2cb4105d5de6d42c3fc2726c48d28a9b08fb3
+    name: harness-delegate-ng
+    type: application
+    urls:
+    - harness-delegate-ng-1.0.4.tgz
+    version: 1.0.4
+  - apiVersion: v2
+    appVersion: 1.16.0
     created: "2022-11-22T14:29:12.077663+05:30"
     description: A Helm chart for deploying harness-delegate
     digest: b8334e36bf896dcd89345b3ac6c8622eca5b85741fb86f2afe560c433c50ad26
@@ -51,4 +61,4 @@ entries:
     urls:
     - harness-delegate-ng-0.1.0.tgz
     version: 0.1.0
-generated: "2022-11-22T14:29:12.07653+05:30"
+generated: "2022-11-23T12:02:19.428765+05:30"


### PR DESCRIPTION
JIRA: https://harness.atlassian.net/browse/DEL-5379

Testing:
Tested with low configuration 512, 768 and 1024MB memory. With 512, 768 OOM is thrown, with 1024 delegates comes up and goes down soon after startup. Delegate works fine with 2GB of memory, increase default liveness probe to avoid frequent restarts. This variable is configurable anyways via delegate-values.yaml